### PR TITLE
add some primitives for integers: eq, neq, le, lt

### DIFF
--- a/library/Backends/llvm/package.yaml
+++ b/library/Backends/llvm/package.yaml
@@ -34,6 +34,9 @@ dependencies:
   - bytestring
   - data-structures
 
+ghc-options:
+- -Wincomplete-patterns
+
 default-extensions:
 - BlockArguments
 - DataKinds
@@ -79,4 +82,3 @@ tests:
     - tasty-hunit
     - unordered-containers
     - data-structures
-

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
@@ -56,11 +56,14 @@ llvm =
     -- Typechecking of primitive values.
     hasType :: RawPrimVal -> Param.PrimType PrimTy -> Bool
     hasType t (Param.PrimType ty) = case t of
-      Add -> Param.check3Equal ty
-      Sub -> Param.check3Equal ty
-      Mul -> Param.check3Equal ty
-      LitInt _ -> length ty == 1
-      LitString _ -> length ty == 1
+      PrimAdd -> Param.check3Equal ty
+      PrimSub -> Param.check3Equal ty
+      PrimMul -> Param.check3Equal ty
+      PrimEq -> Param.check3Equal ty
+      PrimLe -> Param.check3Equal ty
+      PrimLeq -> Param.check3Equal ty
+      PrimLitInt _ -> length ty == 1
+      PrimLitString _ -> length ty == 1
 
     -- The primitive LLVM types available to Juvix users.
     builtinTypes :: Param.Builtins PrimTy
@@ -73,10 +76,13 @@ llvm =
     -- The primitive LLVM values available to Juvix users.
     builtinValues :: Param.Builtins RawPrimVal
     builtinValues =
-      [ ("LLVM.add", Add),
-        ("LLVM.sub", Sub),
-        ("LLVM.mul", Mul),
-        ("LLVM.litint", LitInt 0) -- TODO: what to do with the 0?
+      [ ("LLVM.add", PrimAdd),
+        ("LLVM.sub", PrimSub),
+        ("LLVM.mul", PrimMul),
+        ("LLVM.leq", PrimLeq),
+        ("LLVM.le", PrimLe),
+        ("LLVM.eq", PrimEq),
+        ("LLVM.litint", PrimLitInt 0) -- TODO: what to do with the 0?
       ]
 
     -- Translate an integer into a RawPrimVal.
@@ -84,10 +90,10 @@ llvm =
     -- no way to do achieve this due to a lack of information available to the
     -- function.
     integerToRawPrimVal :: Integer -> Maybe RawPrimVal
-    integerToRawPrimVal = Just . LitInt
+    integerToRawPrimVal = Just . PrimLitInt
 
     stringToRawPrimVal :: Text -> Maybe RawPrimVal
-    stringToRawPrimVal = Just . LitString
+    stringToRawPrimVal = Just . PrimLitString
 
 -- | TODO: for now these are just copied over from the Michelson backend.
 instance IR.HasWeak PrimTy where weakBy' _ _ t = t

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Parameterization.hs
@@ -60,6 +60,7 @@ llvm =
       PrimSub -> Param.check3Equal ty
       PrimMul -> Param.check3Equal ty
       PrimEq -> Param.check3Equal ty
+      PrimNeq -> Param.check3Equal ty
       PrimLe -> Param.check3Equal ty
       PrimLeq -> Param.check3Equal ty
       PrimLitInt _ -> length ty == 1

--- a/library/Backends/llvm/src/Juvix/Backends/LLVM/Primitive.hs
+++ b/library/Backends/llvm/src/Juvix/Backends/LLVM/Primitive.hs
@@ -27,11 +27,15 @@ arityTy _ = 0
 
 -- | Raw representation of some primitives of LLVM.
 data RawPrimVal
-  = Add
-  | Sub
-  | Mul
-  | LitInt Integer
-  | LitString Text
+  = PrimAdd
+  | PrimSub
+  | PrimMul
+  | PrimLeq
+  | PrimLe
+  | PrimEq
+  | PrimNeq
+  | PrimLitInt Integer
+  | PrimLitString Text
   deriving (Eq, Show, Read)
 
 -- | The primitive values as exposed to users of Juvix, wrapping inside a
@@ -47,8 +51,12 @@ data CompilationError
 -- | Arity of `RawPrimVal`.
 arityRaw :: RawPrimVal -> Natural
 arityRaw p = case p of
-  Add -> 2
-  Mul -> 2
-  Sub -> 2
-  LitInt {} -> 0
-  LitString {} -> 0
+  PrimAdd -> 2
+  PrimMul -> 2
+  PrimSub -> 2
+  PrimLeq -> 2
+  PrimEq -> 2
+  PrimNeq -> 2
+  PrimLe -> 2
+  PrimLitInt {} -> 0
+  PrimLitString {} -> 0

--- a/library/Backends/llvm/test/Test/Parameterization.hs
+++ b/library/Backends/llvm/test/Test/Parameterization.hs
@@ -62,10 +62,10 @@ typecheckLLVMBinOp instrName instr =
     hasLLVMType instr (primFunc2 LLVM.i16 LLVM.i16 LLVM.i8) @?= False
 
 typecheckLLVMAddTest :: TestTree
-typecheckLLVMAddTest = typecheckLLVMBinOp "add" Add
+typecheckLLVMAddTest = typecheckLLVMBinOp "add" PrimAdd
 
 typecheckLLVMSubTest :: TestTree
-typecheckLLVMSubTest = typecheckLLVMBinOp "sub" Sub
+typecheckLLVMSubTest = typecheckLLVMBinOp "sub" PrimSub
 
 typecheckLLVMMulTest :: TestTree
-typecheckLLVMMulTest = typecheckLLVMBinOp "mul" Mul
+typecheckLLVMMulTest = typecheckLLVMBinOp "mul" PrimMul

--- a/library/Core/src/Juvix/Core/Parameterisation.hs
+++ b/library/Core/src/Juvix/Core/Parameterisation.hs
@@ -334,17 +334,14 @@ instance PP.ToPPAnn (PP.Ann ty) => PP.ToPPAnn (PPAnn ty) where
 check3Equal :: Eq a => NonEmpty a -> Bool
 check3Equal (x :| [y, z])
   | x == y && x == z = True
-  | otherwise = False
-check3Equal (_ :| _) = False
+check3Equal _ = False
 
 check2Equal :: Eq a => NonEmpty a -> Bool
 check2Equal (x :| [y])
   | x == y = True
-  | otherwise = False
-check2Equal (_ :| _) = False
+check2Equal _ = False
 
 checkFirst2AndLast :: Eq t => NonEmpty t -> (t -> Bool) -> Bool
 checkFirst2AndLast (x :| [y, last]) check
   | check2Equal (x :| [y]) && check last = True
-  | otherwise = False
-checkFirst2AndLast (_ :| _) _ = False
+checkFirst2AndLast _ _ = False


### PR DESCRIPTION
this PR adds some primitives to the llvm backend.
Namely:
- PrimLeq.
- PrimLt.
- PrimEq.
- PrimNeq.

Currently, it is assumed that the arguments are integer types.
More work should be done to adapt these to floats.